### PR TITLE
install psmisc to use fuser command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ RUN apt-get -q update && apt-get -q -y install \
     build-essential \
     libssl-dev \
     asterisk-sounds-main \
-    asterisk-moh-opsound-wav
+    asterisk-moh-opsound-wav \
+    # wazo-calld integration tests need fuser
+    psmisc
 COPY . /usr/src/chan-test
 WORKDIR /usr/src/chan-test
 


### PR DESCRIPTION
reason: wazo-calld is the only one that use this image and it need to
use fuser. The recent dependency update of asterisk as probably
removed it.